### PR TITLE
Add GA4 with Consent Mode v2 and a cookie banner.

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -18,7 +18,7 @@ jobs:
           bundler-cache: true
 
       - name: Build site
-        run: bundle exec jekyll build --trace
+        run: JEKYLL_ENV=production bundle exec jekyll build --trace
 
       - name: Verify output
         run: test -f _site/index.html

--- a/_config.yml
+++ b/_config.yml
@@ -13,8 +13,8 @@ author:
   name: Pablo Lanaspa Ferrer
   image: bio_img.png
 
-# Google Analytics (leave blank to disable)
-google_analytics:
+# Google Analytics 4 (leave blank to disable)
+google_analytics: G-6SDG48R4SK
 
 # Build settings
 markdown: kramdown

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,0 +1,12 @@
+<div id="cookie-consent" class="cookie-consent" role="dialog" aria-labelledby="cookie-consent-title" aria-live="polite" hidden>
+  <div class="cookie-consent__inner">
+    <p id="cookie-consent-title" class="cookie-consent__text">
+      This site uses cookies for analytics to understand how visitors use the content.
+      <a href="{{ '/legal/' | relative_url }}">Privacy &amp; cookies</a>
+    </p>
+    <div class="cookie-consent__actions">
+      <button type="button" id="cookie-consent-reject" class="cookie-consent__btn cookie-consent__btn--secondary">Reject</button>
+      <button type="button" id="cookie-consent-accept" class="cookie-consent__btn cookie-consent__btn--primary">Accept</button>
+    </div>
+  </div>
+</div>

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,8 +1,12 @@
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '{{ site.google_analytics }}');
+
+  gtag('consent', 'default', {
+    'analytics_storage': 'denied',
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'wait_for_update': 500
+  });
 </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,4 +14,8 @@
         crossorigin="anonymous">
 
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+
+  {% if site.google_analytics and jekyll.environment != 'development' %}
+  {% include google-analytics.html %}
+  {% endif %}
 </head>

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,2 +1,5 @@
 <script src="{{ '/js/vendors/zoom.min.js' | relative_url }}" defer></script>
 <script src="{{ '/js/common.js' | relative_url }}" defer></script>
+{% if site.google_analytics and jekyll.environment != 'development' %}
+<script src="{{ '/js/cookie-consent.js' | relative_url }}" defer></script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,11 +3,7 @@
 
 {% include head.html %}
 
-<body>
-
-  {% if site.google_analytics %}
-  {% include google-analytics.html %}
-  {% endif %}
+<body{% if site.google_analytics and jekyll.environment != 'development' %} data-ga-id="{{ site.google_analytics }}"{% endif %}>
 
   {% include header.html %}
 
@@ -21,6 +17,10 @@
 
 
   {% include footer.html %}
+
+  {% if site.google_analytics and jekyll.environment != 'development' %}
+  {% include cookie-consent.html %}
+  {% endif %}
 
   {% include javascripts.html %}
 </body>

--- a/_pages/legal.md
+++ b/_pages/legal.md
@@ -9,6 +9,9 @@ summary: "Sitio web personal de Pablo Lanaspa. Publico opiniones personales acer
 
   <p>La presente página se constituye como el Aviso Legal y las Condiciones de Uso que regulan el acceso, navegación y uso de mi sitio web personal ubicada en planaspa.com. Para comunicarse conmigo, se debe de escribir un correo electrónico a la siguiente dirección: <a href="mailto:info@planaspa.com">info@planaspa.com</a>.</p>
 
-  <h3>Cookies</h3>
-  <p>Este sitio web no utiliza cookies de seguimiento ni herramientas de analítica. Solo pueden emplearse cookies técnicas estrictamente necesarias para el funcionamiento básico del sitio, gestionadas por GitHub Pages como proveedor de alojamiento.</p>
+  <h3>Cookies &amp; analytics</h3>
+  <p>This site uses <strong>Google Analytics 4</strong> to understand how visitors use the content (pages viewed, general usage patterns). Analytics cookies are only set if you click <strong>Accept</strong> on the cookie banner. If you click <strong>Reject</strong>, no analytics cookies are used.</p>
+  <p>Google Analytics is provided by Google Ireland Limited. Data may be processed in the United States and other countries. Google’s privacy policy is available at <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">policies.google.com/privacy</a>.</p>
+  <p>You can withdraw consent at any time by clearing this site’s data in your browser (local storage key: <code>cookie_consent</code>) and reloading the page.</p>
+  <p>Strictly necessary technical cookies may still be used for basic site operation by the hosting provider (GitHub Pages).</p>
 </div>

--- a/_sass/3-modules/_cookie-consent.scss
+++ b/_sass/3-modules/_cookie-consent.scss
@@ -1,0 +1,77 @@
+.cookie-consent {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1000;
+  padding: $base-spacing-unit;
+  background: rgba($dark, 0.96);
+  color: $white;
+  box-shadow: 0 -2px 12px rgba($black, 0.15);
+
+  &[hidden] {
+    display: none;
+  }
+
+  &__inner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: $base-spacing-unit;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  &__text {
+    flex: 1 1 280px;
+    margin: 0;
+    font-size: 14px;
+    line-height: 22px;
+
+    a {
+      color: $brand-color;
+      text-decoration: underline;
+
+      &:hover {
+        color: lighten($brand-color, 10%);
+      }
+    }
+  }
+
+  &__actions {
+    display: flex;
+    flex-shrink: 0;
+    gap: 10px;
+  }
+
+  &__btn {
+    padding: 8px 18px;
+    border: 0;
+    border-radius: $global-radius;
+    font-family: $base-font-family;
+    font-size: 14px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: $global-transition;
+
+    &--primary {
+      background: $brand-color;
+      color: $dark;
+
+      &:hover {
+        background: lighten($brand-color, 8%);
+      }
+    }
+
+    &--secondary {
+      background: transparent;
+      color: $white;
+      box-shadow: inset 0 0 0 1px rgba($white, 0.35);
+
+      &:hover {
+        background: rgba($white, 0.08);
+      }
+    }
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -19,6 +19,7 @@
 @import "3-modules/hero";
 @import "3-modules/pagination";
 @import "3-modules/footer";
+@import "3-modules/cookie-consent";
 
 @import "4-layouts/page-home";
 @import "4-layouts/page";

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -1,0 +1,119 @@
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'cookie_consent';
+  var body = document.body;
+  var measurementId = body && body.getAttribute('data-ga-id');
+
+  if (!measurementId) {
+    return;
+  }
+
+  function getConsent() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function setConsent(value) {
+    try {
+      localStorage.setItem(STORAGE_KEY, value);
+    } catch (error) {
+      // Storage may be unavailable in private browsing.
+    }
+  }
+
+  function grantAnalyticsConsent() {
+    if (typeof gtag !== 'function') {
+      return;
+    }
+
+    gtag('consent', 'update', {
+      'analytics_storage': 'granted',
+      'ad_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied'
+    });
+  }
+
+  function loadGoogleAnalytics() {
+    if (window.__gaLoaded) {
+      return;
+    }
+
+    window.__gaLoaded = true;
+
+    var script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + measurementId;
+    script.onload = function () {
+      gtag('js', new Date());
+      gtag('config', measurementId);
+    };
+    document.head.appendChild(script);
+  }
+
+  function hideBanner() {
+    var banner = document.getElementById('cookie-consent');
+
+    if (banner) {
+      banner.hidden = true;
+    }
+  }
+
+  function showBanner() {
+    var banner = document.getElementById('cookie-consent');
+
+    if (banner) {
+      banner.hidden = false;
+    }
+  }
+
+  function accept() {
+    setConsent('granted');
+    grantAnalyticsConsent();
+    loadGoogleAnalytics();
+    hideBanner();
+  }
+
+  function reject() {
+    setConsent('denied');
+    hideBanner();
+  }
+
+  function init() {
+    var acceptButton = document.getElementById('cookie-consent-accept');
+    var rejectButton = document.getElementById('cookie-consent-reject');
+    var consent = getConsent();
+
+    if (acceptButton) {
+      acceptButton.addEventListener('click', accept);
+    }
+
+    if (rejectButton) {
+      rejectButton.addEventListener('click', reject);
+    }
+
+    if (consent === 'granted') {
+      grantAnalyticsConsent();
+      loadGoogleAnalytics();
+      hideBanner();
+      return;
+    }
+
+    if (consent === 'denied') {
+      hideBanner();
+      return;
+    }
+
+    showBanner();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
Load analytics only after explicit consent, keep ad signals denied, and build production deploys with JEKYLL_ENV=production so tracking is enabled on the live site.